### PR TITLE
fix: strip quotes from color parameters in badge function

### DIFF
--- a/badgepy/__init__.py
+++ b/badgepy/__init__.py
@@ -118,6 +118,11 @@ def _embed_image(url: str) -> str:
     return "data:image/{};base64,{}".format(image_type, encoded_image)
 
 
+def _normalize_color(color: str) -> str:
+    color = color.strip("'\"")
+    return _NAME_TO_COLOR.get(color, color)
+
+
 def badge(
     left_text: str,
     right_text: Optional[str] = None,
@@ -126,8 +131,8 @@ def badge(
     center_link: Optional[str] = None,
     whole_link: Optional[str] = None,
     logo: Optional[str] = None,
-    left_color: str = "#555",
-    right_color: str = "#007ec6",
+    left_color: Optional[str] = "#555",
+    right_color: Optional[str] = "#007ec6",
     center_color: Optional[str] = None,
     measurer: Optional[text_measurer.TextMeasurer] = None,
     left_title: Optional[str] = None,
@@ -215,11 +220,17 @@ def badge(
         center_image = _embed_image(center_image)
 
     if center_color:
-        center_color = center_color.strip("'\"")
-        center_color = _NAME_TO_COLOR.get(center_color, center_color)
+        center_color = _normalize_color(center_color)
 
-    left_color = left_color.strip("'\"")
-    right_color = right_color.strip("'\"")
+    if left_color is None:
+        left_color = "#555"
+    else:
+        left_color = _normalize_color(left_color)
+
+    if right_color is None:
+        right_color = "#007ec6"
+    else:
+        right_color = _normalize_color(right_color)
 
     right_text_width = None
     if right_text:
@@ -237,8 +248,8 @@ def badge(
         whole_link=whole_link,
         center_link=center_link,
         logo=logo,
-        left_color=_NAME_TO_COLOR.get(left_color, left_color),
-        right_color=_NAME_TO_COLOR.get(right_color, right_color),
+        left_color=left_color,
+        right_color=right_color,
         center_color=center_color,
         left_title=left_title,
         right_title=right_title,

--- a/badgepy/__init__.py
+++ b/badgepy/__init__.py
@@ -215,7 +215,11 @@ def badge(
         center_image = _embed_image(center_image)
 
     if center_color:
+        center_color = center_color.strip("'\"")
         center_color = _NAME_TO_COLOR.get(center_color, center_color)
+
+    left_color = left_color.strip("'\"")
+    right_color = right_color.strip("'\"")
 
     right_text_width = None
     if right_text:

--- a/badgepy/__init__.py
+++ b/badgepy/__init__.py
@@ -118,6 +118,11 @@ def _embed_image(url: str) -> str:
     return "data:image/{};base64,{}".format(image_type, encoded_image)
 
 
+def _normalize_color(color: str) -> str:
+    color = color.strip("'\"")
+    return _NAME_TO_COLOR.get(color, color)
+
+
 def badge(
     left_text: str,
     right_text: Optional[str] = None,
@@ -126,8 +131,8 @@ def badge(
     center_link: Optional[str] = None,
     whole_link: Optional[str] = None,
     logo: Optional[str] = None,
-    left_color: str = "#555",
-    right_color: str = "#007ec6",
+    left_color: Optional[str] = "#555",
+    right_color: Optional[str] = "#007ec6",
     center_color: Optional[str] = None,
     measurer: Optional[text_measurer.TextMeasurer] = None,
     left_title: Optional[str] = None,
@@ -219,11 +224,17 @@ def badge(
         center_image = _embed_image(center_image)
 
     if center_color:
-        center_color = center_color.strip("'\"")
-        center_color = _NAME_TO_COLOR.get(center_color, center_color)
+        center_color = _normalize_color(center_color)
 
-    left_color = left_color.strip("'\"")
-    right_color = right_color.strip("'\"")
+    if left_color is None:
+        left_color = "#555"
+    else:
+        left_color = _normalize_color(left_color)
+
+    if right_color is None:
+        right_color = "#007ec6"
+    else:
+        right_color = _normalize_color(right_color)
 
     right_text_width = None
     if right_text:
@@ -241,8 +252,8 @@ def badge(
         whole_link=whole_link,
         center_link=center_link,
         logo=logo,
-        left_color=_NAME_TO_COLOR.get(left_color, left_color),
-        right_color=_NAME_TO_COLOR.get(right_color, right_color),
+        left_color=left_color,
+        right_color=right_color,
         center_color=center_color,
         left_title=left_title,
         right_title=right_title,

--- a/badgepy/__init__.py
+++ b/badgepy/__init__.py
@@ -219,7 +219,11 @@ def badge(
         center_image = _embed_image(center_image)
 
     if center_color:
+        center_color = center_color.strip("'\"")
         center_color = _NAME_TO_COLOR.get(center_color, center_color)
+
+    left_color = left_color.strip("'\"")
+    right_color = right_color.strip("'\"")
 
     right_text_width = None
     if right_text:

--- a/tests/test_badgepy.py
+++ b/tests/test_badgepy.py
@@ -98,6 +98,28 @@ class TestbadgepyBadge(unittest.TestCase):
                         % (file_name, diff, html.name)
                     )
 
+    def test_quoted_colors_are_normalized(self):
+        svg = badgepy.badge(
+            left_text="build",
+            right_text="passing",
+            left_color="'grey'",
+            right_color='"green"',
+        )
+
+        self.assertIn('fill="#555"', svg)
+        self.assertIn('fill="#97CA00"', svg)
+
+    def test_none_colors_use_defaults(self):
+        svg = badgepy.badge(
+            left_text="build",
+            right_text="passing",
+            left_color=None,
+            right_color=None,
+        )
+
+        self.assertIn('fill="#555"', svg)
+        self.assertIn('fill="#007ec6"', svg)
+
 
 class TestEmbedImage(unittest.TestCase):
     """Tests for badgepy._embed_image."""

--- a/tests/test_badgepy.py
+++ b/tests/test_badgepy.py
@@ -115,6 +115,28 @@ class TestbadgepyBadge(unittest.TestCase):
                         % (file_name, diff, html.name)
                     )
 
+    def test_quoted_colors_are_normalized(self):
+        svg = badgepy.badge(
+            left_text="build",
+            right_text="passing",
+            left_color="'grey'",
+            right_color='"green"',
+        )
+
+        self.assertIn('fill="#555"', svg)
+        self.assertIn('fill="#97CA00"', svg)
+
+    def test_none_colors_use_defaults(self):
+        svg = badgepy.badge(
+            left_text="build",
+            right_text="passing",
+            left_color=None,
+            right_color=None,
+        )
+
+        self.assertIn('fill="#555"', svg)
+        self.assertIn('fill="#007ec6"', svg)
+
 
 class TestEmbedImage(unittest.TestCase):
     """Tests for badgepy._embed_image."""


### PR DESCRIPTION
## Description

<!-- Provide a concise summary of the changes and the motivation behind them. -->

## Type of Change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🚀 New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 👻 Maintenance / chore

## Related Issues

Closes #28 

