### PR TITLE
chore: remove python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Install system dependencies
-        if: ${{ ! contains(fromJSON('["3.9", "3.10"]'), matrix.python-version) }}
+        if: ${{ matrix.python-version != '3.10' }}
         run: sudo apt-get update && sudo apt-get install -y libjpeg-dev
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/badgepy/__init__.py
+++ b/badgepy/__init__.py
@@ -31,7 +31,6 @@ gh-badges library
 
 import base64
 import mimetypes
-from typing import Optional
 import urllib.parse
 from xml.dom import minidom
 
@@ -125,22 +124,22 @@ def _normalize_color(color: str) -> str:
 
 def badge(
     left_text: str,
-    right_text: Optional[str] = None,
-    left_link: Optional[str] = None,
-    right_link: Optional[str] = None,
-    center_link: Optional[str] = None,
-    whole_link: Optional[str] = None,
-    logo: Optional[str] = None,
-    left_color: Optional[str] = "#555",
-    right_color: Optional[str] = "#007ec6",
-    center_color: Optional[str] = None,
-    measurer: Optional[text_measurer.TextMeasurer] = None,
-    left_title: Optional[str] = None,
-    right_title: Optional[str] = None,
-    center_title: Optional[str] = None,
-    whole_title: Optional[str] = None,
-    right_image: Optional[str] = None,
-    center_image: Optional[str] = None,
+    right_text: str | None = None,
+    left_link: str | None = None,
+    right_link: str | None = None,
+    center_link: str | None = None,
+    whole_link: str | None = None,
+    logo: str | None = None,
+    left_color: str | None = "#555",
+    right_color: str | None = "#007ec6",
+    center_color: str | None = None,
+    measurer: text_measurer.TextMeasurer | None = None,
+    left_title: str | None = None,
+    right_title: str | None = None,
+    center_title: str | None = None,
+    whole_title: str | None = None,
+    right_image: str | None = None,
+    center_image: str | None = None,
     embed_logo: bool = False,
     embed_right_image: bool = False,
     embed_center_image: bool = False,

--- a/badgepy/parsers/coverage.py
+++ b/badgepy/parsers/coverage.py
@@ -26,7 +26,6 @@ Example Cobertura XML structure::
 import os
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Optional, Union
 
 from badgepy.presets import coverage_badge
 
@@ -36,20 +35,20 @@ class CoverageResult:
     """Parsed coverage results."""
 
     line_rate: float
-    branch_rate: Optional[float]
+    branch_rate: float | None
 
     @property
     def line_percentage(self) -> float:
         return self.line_rate * 100
 
     @property
-    def branch_percentage(self) -> Optional[float]:
+    def branch_percentage(self) -> float | None:
         if self.branch_rate is not None:
             return self.branch_rate * 100
         return None
 
 
-def parse_coverage(source: Union[str, "os.PathLike[str]"]) -> CoverageResult:
+def parse_coverage(source: str | os.PathLike[str]) -> CoverageResult:
     """Parse a Cobertura XML coverage file.
 
     Args:
@@ -71,7 +70,7 @@ def parse_coverage(source: Union[str, "os.PathLike[str]"]) -> CoverageResult:
     return CoverageResult(line_rate=line_rate, branch_rate=branch_rate)
 
 
-def badges_from_coverage(source: Union[str, "os.PathLike[str]"]) -> dict[str, str]:
+def badges_from_coverage(source: str | os.PathLike[str]) -> dict[str, str]:
     """Parse a Cobertura XML file and generate badge SVGs.
 
     Args:

--- a/badgepy/parsers/generic.py
+++ b/badgepy/parsers/generic.py
@@ -31,12 +31,11 @@ JSON::
 
 import json
 import os
-from typing import Union
 
 from badgepy.presets import custom_badge
 
 
-def parse_generic(source: Union[str, "os.PathLike[str]"]) -> dict[str, str]:
+def parse_generic(source: str | os.PathLike[str]) -> dict[str, str]:
     """Parse a generic key-value or JSON file.
 
     Args:
@@ -67,7 +66,7 @@ def parse_generic(source: Union[str, "os.PathLike[str]"]) -> dict[str, str]:
 
 
 def badges_from_generic(
-    source: Union[str, "os.PathLike[str]"],
+    source: str | os.PathLike[str],
     color: str = "blue",
 ) -> dict[str, str]:
     """Parse a generic file and generate a badge for each key-value pair.

--- a/badgepy/parsers/junit.py
+++ b/badgepy/parsers/junit.py
@@ -28,7 +28,6 @@ Example JUnit XML structure::
 import os
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
-from typing import Union
 
 from badgepy.presets import tests_badge
 
@@ -47,7 +46,7 @@ class JUnitResult:
         return self.tests - self.failures - self.errors - self.skipped
 
 
-def parse_junit(source: Union[str, "os.PathLike[str]"]) -> JUnitResult:
+def parse_junit(source: str | os.PathLike[str]) -> JUnitResult:
     """Parse a JUnit XML file and extract test counts.
 
     Args:
@@ -85,7 +84,7 @@ def parse_junit(source: Union[str, "os.PathLike[str]"]) -> JUnitResult:
     )
 
 
-def badges_from_junit(source: Union[str, "os.PathLike[str]"]) -> dict[str, str]:
+def badges_from_junit(source: str | os.PathLike[str]) -> dict[str, str]:
     """Parse a JUnit XML file and generate badge SVGs.
 
     Args:

--- a/badgepy/parsers/structured.py
+++ b/badgepy/parsers/structured.py
@@ -16,7 +16,7 @@
 import json
 import os
 import re
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from badgepy.presets import custom_badge
 
@@ -154,8 +154,8 @@ def _parse_basic_toml(content: str) -> dict[str, Any]:
 
 
 def load_structured_data(
-    source: Union[str, "os.PathLike[str]"],
-    input_format: Optional[str] = None,
+    source: str | os.PathLike[str],
+    input_format: str | None = None,
 ) -> Any:
     """Load JSON or TOML from a local file."""
     path = os.fspath(source)
@@ -170,7 +170,7 @@ def load_structured_data(
     raise ValueError(f"unsupported structured data format: {fmt}")
 
 
-def select_value(data: Any, query: Optional[str] = None) -> Any:
+def select_value(data: Any, query: str | None = None) -> Any:
     """Select a value with a small dot-and-index path syntax.
 
     Examples: ``project.version``, ``items[0].name``, ``tool.badge.status``.
@@ -208,7 +208,7 @@ def stringify_value(value: Any) -> str:
     return str(value)
 
 
-def render_template(template: Optional[str], data: Any, selected_value: Any) -> str:
+def render_template(template: str | None, data: Any, selected_value: Any) -> str:
     """Render a badge message template.
 
     ``{value}`` expands to the selected query value. Other fields are treated
@@ -226,7 +226,7 @@ def render_template(template: Optional[str], data: Any, selected_value: Any) -> 
     return _TEMPLATE_FIELD_RE.sub(replace, template)
 
 
-def parse_thresholds(spec: Optional[str]) -> Optional[list[tuple[float, str]]]:
+def parse_thresholds(spec: str | None) -> list[tuple[float, str]] | None:
     """Parse ``min:color`` threshold specs such as ``90:green,0:red``."""
     if not spec:
         return None
@@ -242,8 +242,8 @@ def parse_thresholds(spec: Optional[str]) -> Optional[list[tuple[float, str]]]:
 
 
 def color_for_value(
-    value: Any, thresholds: Optional[list[tuple[float, str]]]
-) -> Optional[str]:
+    value: Any, thresholds: list[tuple[float, str]] | None
+) -> str | None:
     """Return the threshold color for a selected numeric value."""
     if thresholds is None:
         return None
@@ -256,13 +256,13 @@ def color_for_value(
 
 
 def badge_from_structured_data(
-    source: Union[str, "os.PathLike[str]"],
-    label: Optional[str] = None,
-    query: Optional[str] = None,
+    source: str | os.PathLike[str],
+    label: str | None = None,
+    query: str | None = None,
     color: str = "blue",
-    template: Optional[str] = None,
-    thresholds: Optional[Union[str, list[tuple[float, str]]]] = None,
-    input_format: Optional[str] = None,
+    template: str | None = None,
+    thresholds: str | list[tuple[float, str]] | None = None,
+    input_format: str | None = None,
 ) -> str:
     """Generate a badge from a JSON or TOML file."""
     data = load_structured_data(source, input_format=input_format)
@@ -284,7 +284,7 @@ def badge_from_structured_data(
 
 
 def package_from_lock(
-    source: Union[str, "os.PathLike[str]"],
+    source: str | os.PathLike[str],
     package_name: str,
 ) -> dict[str, Any]:
     """Find a package entry in a uv.lock or poetry.lock TOML file."""
@@ -304,11 +304,11 @@ def package_from_lock(
 
 
 def badge_from_lock(
-    source: Union[str, "os.PathLike[str]"],
+    source: str | os.PathLike[str],
     package_name: str,
-    label: Optional[str] = None,
+    label: str | None = None,
     color: str = "blue",
-    template: Optional[str] = None,
+    template: str | None = None,
 ) -> str:
     """Generate a package version badge from a uv.lock or poetry.lock file."""
     package = package_from_lock(source, package_name)

--- a/badgepy/presets.py
+++ b/badgepy/presets.py
@@ -22,8 +22,6 @@ sensible defaults for colors and labels.
 '<svg...</svg>'
 """
 
-from typing import Optional
-
 import badgepy
 
 # Status-to-color mappings for build badges
@@ -49,7 +47,7 @@ _DEFAULT_COVERAGE_THRESHOLDS = [
 
 def _color_for_coverage(
     percentage: float,
-    thresholds: Optional[list[tuple[float, str]]] = None,
+    thresholds: list[tuple[float, str]] | None = None,
 ) -> str:
     """Determine the badge color based on coverage percentage."""
     if thresholds is None:
@@ -80,7 +78,7 @@ def build_badge(status: str, label: str = "build") -> str:
 def coverage_badge(
     percentage: float,
     label: str = "coverage",
-    thresholds: Optional[list[tuple[float, str]]] = None,
+    thresholds: list[tuple[float, str]] | None = None,
 ) -> str:
     """Generate a coverage badge with automatic color based on percentage.
 
@@ -105,12 +103,12 @@ def coverage_badge(
 
 
 def progress_badge(
-    percentage: Optional[float] = None,
+    percentage: float | None = None,
     label: str = "progress",
-    numerator: Optional[float] = None,
-    denominator: Optional[float] = None,
-    message: Optional[str] = None,
-    thresholds: Optional[list[tuple[float, str]]] = None,
+    numerator: float | None = None,
+    denominator: float | None = None,
+    message: str | None = None,
+    thresholds: list[tuple[float, str]] | None = None,
 ) -> str:
     """Generate a progress badge with coverage-style threshold colors.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "badgepy"
 description = "A library and command-line tool for generating Github-style badges"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 license = { file = "LICENSE" }
 authors = [
@@ -18,7 +18,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python 3.9 reached end-of-life. This PR:

- Bumps `requires-python` from `>=3.9` to `>=3.10`
- Removes `Programming Language :: Python :: 3.9` classifier from pyproject.toml
- Drops Python 3.9 from the CI compatibility matrix