### PR TITLE
feat: add from-pypi command for download-count badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Generate badges directly from test and coverage report files — no external API
 | `badgepy from-coverage tests/coverage.xml --output-dir badges/` | ![coverage](badges/coverage.svg) ![branch-coverage](badges/branch-coverage.svg) |
 
 ```sh
+# PyPI download counts, fetched from pypistats.org (avoids shields.io's
+# shared upstream rate limit — run this in CI and commit the SVG)
+badgepy from-pypi python-multipart --metric dm -o badges/downloads.svg
+
 # From generic key-value or JSON files
 badgepy from-generic metrics.json --output-dir badges/
 
@@ -233,6 +237,42 @@ svg = badge_from_structured_data('pyproject.toml', query='project.version', labe
 ```
 
 See the [CI Integration Guide](docs/ci-integration.md) for GitHub Actions, GitLab CI, and Jenkins examples.
+
+### PyPI Download Badges
+
+Tired of `https://img.shields.io/pypi/dm/<package>` showing **"rate limited by
+upstream service"**? That error comes from shields.io sharing a single upstream
+quota across every README on the internet — it has nothing to do with your
+project. badgepy fetches the count from [pypistats.org](https://pypistats.org)
+directly, so you control retries and caching, then renders a static SVG that
+never hits a shared rate limit at display time:
+
+```sh
+# Downloads per month (dm), week (dw), or day (dd)
+badgepy from-pypi python-multipart --metric dm -o badges/downloads.svg
+
+# Custom label, color, and message template
+badgepy from-pypi python-multipart \
+    --metric dm \
+    --label "pypi downloads" \
+    --color blue \
+    --template "{value}/month" \
+    -o badges/downloads.svg
+```
+
+Run it on a schedule in CI, commit the generated SVG, and reference the committed
+file in your README — no runtime call to shields.io, so the badge always renders.
+Use `--on-error hide` (empty badge) or `--on-error badge` (neutral fallback) to
+keep builds green if pypistats.org is briefly unavailable.
+
+From Python:
+
+```python
+from badgepy.parsers.pypi import badge_from_pypi, download_count
+
+svg = badge_from_pypi('python-multipart', metric='dm')  # '<svg...>'
+n = download_count('python-multipart', 'dm')            # raw integer
+```
 
 ### Output to File
 

--- a/badgepy/__main__.py
+++ b/badgepy/__main__.py
@@ -233,6 +233,29 @@ def _cmd_from_structured(args: argparse.Namespace, input_format: str) -> None:
     _output_badge(svg, args)
 
 
+def _cmd_from_pypi(args: argparse.Namespace) -> None:
+    """Generate a PyPI download-count badge from pypistats.org."""
+    from badgepy.parsers.pypi import badge_from_pypi
+
+    try:
+        svg = badge_from_pypi(
+            args.package,
+            metric=args.metric,
+            label=args.label,
+            color=args.color or "blue",
+            template=args.template,
+            timeout=args.timeout,
+        )
+    except Exception as exc:
+        if args.on_error == "raise":
+            print(f"failed to generate badge: {exc}", file=sys.stderr)
+            sys.exit(1)
+        args.query = args.label or "downloads"
+        svg = _fallback_badge(args)
+
+    _output_badge(svg, args)
+
+
 def _cmd_from_lock(args: argparse.Namespace) -> None:
     """Generate a package badge from a uv.lock or poetry.lock file."""
     from badgepy.parsers.structured import badge_from_lock
@@ -669,6 +692,65 @@ def main():
     )
     _add_output_args(lock_parser)
 
+    # ── from-pypi subcommand ──
+    pypi_parser = subparsers.add_parser(
+        "from-pypi",
+        help="generate a PyPI download-count badge from pypistats.org",
+        description=(
+            "Fetch download counts from pypistats.org and render a static "
+            "badge. Run this in CI to avoid shields.io's shared upstream "
+            "rate limits at display time."
+        ),
+    )
+    pypi_parser.add_argument(
+        "package",
+        help="the PyPI project name, e.g. python-multipart",
+    )
+    pypi_parser.add_argument(
+        "--metric",
+        choices=["dd", "dw", "dm"],
+        default="dm",
+        help="downloads per day (dd), week (dw), or month (dm); default: dm",
+    )
+    pypi_parser.add_argument(
+        "--label",
+        default=None,
+        help="left-hand badge label (default: downloads)",
+    )
+    pypi_parser.add_argument(
+        "--template",
+        default=None,
+        help="right-hand template using {value}, {count}, or {period}",
+    )
+    pypi_parser.add_argument(
+        "--color",
+        default=None,
+        help="badge color (default: blue)",
+    )
+    pypi_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="HTTP request timeout in seconds (default: 10)",
+    )
+    pypi_parser.add_argument(
+        "--on-error",
+        choices=["raise", "badge", "hide"],
+        default="raise",
+        help="how to handle fetch or parse errors",
+    )
+    pypi_parser.add_argument(
+        "--error-message",
+        default="unknown",
+        help="fallback badge message for --on-error=badge",
+    )
+    pypi_parser.add_argument(
+        "--error-color",
+        default="lightgrey",
+        help="fallback badge color for --on-error=badge",
+    )
+    _add_output_args(pypi_parser)
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -690,6 +772,8 @@ def main():
         _cmd_from_structured(args, "toml")
     elif args.command == "from-lock":
         _cmd_from_lock(args)
+    elif args.command == "from-pypi":
+        _cmd_from_pypi(args)
 
 
 if __name__ == "__main__":

--- a/badgepy/parsers/__init__.py
+++ b/badgepy/parsers/__init__.py
@@ -23,6 +23,12 @@ from badgepy.parsers.structured import (
     package_from_lock,
     select_value,
 )
+from badgepy.parsers.pypi import (
+    badge_from_pypi,
+    download_count,
+    fetch_recent_downloads,
+    humanize_count,
+)
 
 __all__ = [
     "parse_junit",
@@ -36,4 +42,8 @@ __all__ = [
     "load_structured_data",
     "package_from_lock",
     "select_value",
+    "badge_from_pypi",
+    "download_count",
+    "fetch_recent_downloads",
+    "humanize_count",
 ]

--- a/badgepy/parsers/pypi.py
+++ b/badgepy/parsers/pypi.py
@@ -23,6 +23,8 @@ never hits a shared rate limit at display time.
 '<svg...</svg>'
 """
 
+from urllib.parse import quote
+
 import requests
 
 from badgepy.presets import custom_badge
@@ -91,7 +93,7 @@ def fetch_recent_downloads(
     Returns:
         A dict with ``last_day``, ``last_week`` and ``last_month`` keys.
     """
-    url = PYPISTATS_RECENT_URL.format(package=requests.utils.quote(package))
+    url = PYPISTATS_RECENT_URL.format(package=quote(package, safe=""))
     getter = session.get if session is not None else requests.get
     response = getter(url, timeout=timeout)
     response.raise_for_status()

--- a/badgepy/parsers/pypi.py
+++ b/badgepy/parsers/pypi.py
@@ -1,0 +1,158 @@
+# Copyright 2026 The badgepy Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generate PyPI download-count badges from pypistats.org.
+
+Shields.io's ``pypi/dm`` endpoint frequently returns "rate limited by
+upstream service" because every README on the internet shares the same
+upstream quota. This module lets you query pypistats.org directly from your
+own CI, so you control retries and caching and render a static badge that
+never hits a shared rate limit at display time.
+
+>>> badge_from_pypi('badgepy')             # doctest: +SKIP
+'<svg...</svg>'
+"""
+
+import requests
+
+from badgepy.presets import custom_badge
+
+# pypistats.org exposes recent download totals (last day/week/month) for a
+# single package at this endpoint. It is a different, dedicated upstream from
+# the one shields.io shares across all badge requests.
+PYPISTATS_RECENT_URL = "https://pypistats.org/api/packages/{package}/recent"
+
+# Metric aliases mirror shields.io: dd=downloads/day, dw=downloads/week,
+# dm=downloads/month. Each maps to (pypistats key, human-readable period).
+_METRICS: dict[str, tuple[str, str]] = {
+    "dd": ("last_day", "day"),
+    "dw": ("last_week", "week"),
+    "dm": ("last_month", "month"),
+}
+
+_SUFFIXES = ["", "k", "M", "G", "T"]
+
+
+def humanize_count(count: int) -> str:
+    """Format a download count with a metric suffix, shields.io style.
+
+    Examples: ``999`` -> ``"999"``, ``1234`` -> ``"1.2k"``,
+    ``12345`` -> ``"12k"``, ``1234567`` -> ``"1.2M"``.
+    """
+    number = int(count)
+    value = float(abs(number))
+    magnitude = 0
+    while value >= 1000 and magnitude < len(_SUFFIXES) - 1:
+        value /= 1000
+        magnitude += 1
+
+    if magnitude == 0:
+        return str(number)
+
+    # Guard against rounding a value like 999.9 up to "1000k"; promote it to
+    # the next suffix so the text stays at three characters.
+    if value >= 999.5 and magnitude < len(_SUFFIXES) - 1:
+        value /= 1000
+        magnitude += 1
+
+    if value >= 10:
+        text = f"{value:.0f}"
+    else:
+        text = f"{value:.1f}".rstrip("0").rstrip(".")
+
+    sign = "-" if number < 0 else ""
+    return f"{sign}{text}{_SUFFIXES[magnitude]}"
+
+
+def fetch_recent_downloads(
+    package: str,
+    *,
+    timeout: float = 10.0,
+    session: requests.Session | None = None,
+) -> dict[str, int]:
+    """Fetch recent download counts for a package from pypistats.org.
+
+    Args:
+        package: The PyPI project name (e.g. ``python-multipart``).
+        timeout: Per-request timeout in seconds.
+        session: Optional pre-configured ``requests.Session`` (useful for
+            retries or custom headers in CI).
+
+    Returns:
+        A dict with ``last_day``, ``last_week`` and ``last_month`` keys.
+    """
+    url = PYPISTATS_RECENT_URL.format(package=requests.utils.quote(package))
+    getter = session.get if session is not None else requests.get
+    response = getter(url, timeout=timeout)
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError(f"unexpected pypistats response for {package!r}")
+    return {str(key): int(value) for key, value in data.items()}
+
+
+def download_count(
+    package: str,
+    metric: str = "dm",
+    *,
+    timeout: float = 10.0,
+    session: requests.Session | None = None,
+) -> int:
+    """Return the download count for the given package and metric."""
+    if metric not in _METRICS:
+        raise ValueError(
+            f"unknown metric {metric!r}; choose from {', '.join(_METRICS)}"
+        )
+    key, _period = _METRICS[metric]
+    data = fetch_recent_downloads(package, timeout=timeout, session=session)
+    if key not in data:
+        raise KeyError(f"pypistats response missing {key!r} for {package!r}")
+    return data[key]
+
+
+def badge_from_pypi(
+    package: str,
+    metric: str = "dm",
+    label: str | None = None,
+    color: str = "blue",
+    template: str | None = None,
+    *,
+    timeout: float = 10.0,
+    session: requests.Session | None = None,
+) -> str:
+    """Generate a download-count badge for a PyPI package.
+
+    Args:
+        package: The PyPI project name.
+        metric: One of ``dd`` (day), ``dw`` (week), ``dm`` (month).
+        label: Left-hand label (defaults to ``downloads``).
+        color: Badge color (defaults to ``blue``).
+        template: Optional right-hand template. ``{value}`` expands to the
+            humanized count, ``{count}`` to the raw integer, and ``{period}``
+            to ``day``/``week``/``month``. Defaults to ``{value}/{period}``.
+
+    Returns:
+        SVG string of the badge.
+    """
+    if metric not in _METRICS:
+        raise ValueError(
+            f"unknown metric {metric!r}; choose from {', '.join(_METRICS)}"
+        )
+    _key, period = _METRICS[metric]
+    count = download_count(package, metric, timeout=timeout, session=session)
+    humanized = humanize_count(count)
+    message = (template or "{value}/{period}").format(
+        value=humanized, count=count, period=period
+    )
+    return custom_badge(label=label or "downloads", message=message, color=color)

--- a/docs/shields-migration.md
+++ b/docs/shields-migration.md
@@ -80,6 +80,34 @@ badgepy from-json coverage-summary.json \
 badgepy from-json optional-metrics.json --query downloads --on-error hide -o badges/downloads.svg
 ```
 
+## Replacing `pypi/dm` download badges
+
+`https://img.shields.io/pypi/dm/<package>` frequently renders as
+**"rate limited by upstream service"** because shields.io shares one upstream
+quota across every README that uses it. badgepy queries
+[pypistats.org](https://pypistats.org) directly from your own CI, so you are not
+sharing that quota, and renders a static SVG:
+
+```diff
+- ![downloads](https://img.shields.io/pypi/dm/python-multipart)
++ ![downloads](badges/downloads.svg)
+```
+
+Generate and commit the SVG on a schedule:
+
+```bash
+badgepy from-pypi python-multipart --metric dm -o badges/downloads.svg
+```
+
+| shields.io URL | badgepy CLI command |
+|---|---|
+| `https://img.shields.io/pypi/dm/<pkg>` | `badgepy from-pypi <pkg> --metric dm` |
+| `https://img.shields.io/pypi/dw/<pkg>` | `badgepy from-pypi <pkg> --metric dw` |
+| `https://img.shields.io/pypi/dd/<pkg>` | `badgepy from-pypi <pkg> --metric dd` |
+
+Add `--on-error hide` or `--on-error badge` so a transient pypistats.org outage
+never breaks your build.
+
 ## Preset badges reference
 
 | Preset | Usage | Auto-coloring |

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -387,5 +387,77 @@ class TestOutput(unittest.TestCase):
                 self.assertTrue(os.path.exists(p))
 
 
+class TestPyPIParser(unittest.TestCase):
+    def _fake_get(self, data):
+        from unittest import mock
+
+        response = mock.Mock()
+        response.raise_for_status = mock.Mock()
+        response.json = mock.Mock(return_value={"data": data, "package": "pkg"})
+        return mock.Mock(return_value=response)
+
+    def test_humanize_count(self):
+        from badgepy.parsers.pypi import humanize_count
+
+        self.assertEqual(humanize_count(0), "0")
+        self.assertEqual(humanize_count(999), "999")
+        self.assertEqual(humanize_count(1234), "1.2k")
+        self.assertEqual(humanize_count(12345), "12k")
+        self.assertEqual(humanize_count(123456), "123k")
+        self.assertEqual(humanize_count(1234567), "1.2M")
+        self.assertEqual(humanize_count(999999), "1M")
+
+    def test_fetch_recent_downloads(self):
+        from unittest import mock
+        from badgepy.parsers import pypi
+
+        fake = self._fake_get({"last_day": 100, "last_week": 700, "last_month": 3000})
+        with mock.patch.object(pypi.requests, "get", fake):
+            data = pypi.fetch_recent_downloads("python-multipart")
+        self.assertEqual(data["last_month"], 3000)
+        called_url = fake.call_args[0][0]
+        self.assertIn("python-multipart", called_url)
+
+    def test_download_count_metric(self):
+        from unittest import mock
+        from badgepy.parsers import pypi
+
+        fake = self._fake_get({"last_day": 100, "last_week": 700, "last_month": 3000})
+        with mock.patch.object(pypi.requests, "get", fake):
+            self.assertEqual(pypi.download_count("pkg", "dm"), 3000)
+            self.assertEqual(pypi.download_count("pkg", "dw"), 700)
+            self.assertEqual(pypi.download_count("pkg", "dd"), 100)
+
+    def test_download_count_bad_metric(self):
+        from badgepy.parsers import pypi
+
+        with self.assertRaises(ValueError):
+            pypi.download_count("pkg", "bogus")
+
+    def test_badge_from_pypi(self):
+        from unittest import mock
+        from badgepy.parsers import pypi
+
+        fake = self._fake_get(
+            {"last_day": 100, "last_week": 700, "last_month": 1234567}
+        )
+        with mock.patch.object(pypi.requests, "get", fake):
+            svg = pypi.badge_from_pypi("python-multipart", metric="dm")
+        self.assertIn("downloads", svg)
+        self.assertIn("1.2M/month", svg)
+
+    def test_badge_from_pypi_template(self):
+        from unittest import mock
+        from badgepy.parsers import pypi
+
+        fake = self._fake_get({"last_day": 100, "last_week": 700, "last_month": 3000})
+        with mock.patch.object(pypi.requests, "get", fake):
+            svg = pypi.badge_from_pypi(
+                "pkg", metric="dm", label="pypi", template="{value} ({count})"
+            )
+        self.assertIn("pypi", svg)
+        self.assertIn("3k (3000)", svg)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why

`https://img.shields.io/pypi/dm/<package>` frequently renders as **"rate limited by upstream service"**. That error comes from shields.io sharing a single upstream quota (pypistats.org) across every README on the internet — it has nothing to do with the project being badged. Until now badgepy could only generate badges from local files, so it couldn't replace `pypi/dm`.

This PR adds the missing "fetch half": a `from-pypi` command that queries pypistats.org **directly** from your own CI (so you're not on shields.io's shared quota) and renders a static SVG that never hits a rate limit at display time.

## What

- **`badgepy/parsers/pypi.py`** — new module:
  - `fetch_recent_downloads()` — calls `https://pypistats.org/api/packages/{pkg}/recent`
  - `download_count()` — selects `dd`/`dw`/`dm` (day/week/month)
  - `badge_from_pypi()` — renders the badge
  - `humanize_count()` — shields.io-style number formatting (`1234 → 1.2k`, `1234567 → 1.2M`, with a guard so `999999 → 1M` instead of `1000k`)
- **`from-pypi` subcommand** in `__main__.py`:
  ```sh
  badgepy from-pypi python-multipart --metric dm -o badges/downloads.svg
  ```
  Flags: `--metric {dd,dw,dm}`, `--label`, `--color`, `--template` (`{value}`/`{count}`/`{period}`), `--timeout`, and the existing `--on-error {raise,badge,hide}` fallback convention so a transient pypistats.org outage doesn't break the build.
- **Exports** the new functions from `badgepy.parsers`.
- **Docs** — README gains a "PyPI Download Badges" section; `docs/shields-migration.md` gains a `pypi/dm|dw|dd` → `from-pypi` mapping.

## Intended workflow

Run `from-pypi` on a schedule in CI, commit the generated SVG, and reference the committed file in the README — the badge then renders with zero runtime dependency on shields.io. Trade-off: the count refreshes on your schedule rather than in real time.

## Tests

- 6 new unit tests in `tests/test_parsers.py` (`TestPyPIParser`) with mocked HTTP covering `humanize_count`, fetch, metric selection, bad-metric errors, and badge/template rendering.
- Full suite: **74 passed** (`test_badgepy.py` skipped locally — it needs the `xmldiff` dev dependency, unrelated to this change).
- `ruff format` clean on all changed files.

## Note

I couldn't exercise the live network path from the dev sandbox (its egress proxy blocks pypistats.org with a 403), so the live fetch is covered by mocked tests. The `--on-error hide` fallback path was verified end-to-end. Running `badgepy from-pypi python-multipart` in a normal environment will produce a real badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Y2FwGJEaGV98kukPWQxnH

---
_Generated by [Claude Code](https://claude.ai/code/session_013Y2FwGJEaGV98kukPWQxnH)_